### PR TITLE
Fix API auth script

### DIFF
--- a/API/api-auth-script.ps1
+++ b/API/api-auth-script.ps1
@@ -5,7 +5,7 @@ $username="admin"
 $password="password"
 $credentials = "{$username}:{$password}"
 $credentialBytes = [System.Text.Encoding]::ASCII.GetBytes($credentials)
-$base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes($credentialBytes))
+$base64AuthInfo = [Convert]::ToBase64String($credentialBytes)
 $basicAuthHeader = "Basic " + $base64AuthInfo
 
 $urlbase = "https://api.example.com"
@@ -15,5 +15,4 @@ $headers = @{
     Authorization=$basicAuthHeader
     "Content-Type"="application/json"
 }
-
 Invoke-RestMethod -Uri "$urlbase/" -Headers $headers -Method Get


### PR DESCRIPTION
## Summary
- fix Base64 generation in `api-auth-script.ps1`
- clean up the last line and ensure newline at EOF

## Testing
- `python3 - <<'PY'
import base64
cred='admin:password'
cred_bytes=cred.encode('ascii')
base64_auth=base64.b64encode(cred_bytes).decode('ascii')
header='Basic ' + base64_auth
print(header)
PY`

------
https://chatgpt.com/codex/tasks/task_e_686d91901a608324ab6a0cbae3409410