### PR TITLE
Add ethical use disclaimer

### DIFF
--- a/Pen-Test/Basic-Brute-Force.ps1
+++ b/Pen-Test/Basic-Brute-Force.ps1
@@ -1,3 +1,4 @@
+# For authorized testing only. See README.md for ethical use guidelines.
 <#
 .SYNOPSIS
     Attempts to brute force the password for a specified user by testing a list of passwords.

--- a/Pen-Test/File-Generator.ps1
+++ b/Pen-Test/File-Generator.ps1
@@ -1,3 +1,4 @@
+# For authorized testing only. See README.md for ethical use guidelines.
 <#
 .SYNOPSIS
 This script creates a random directory under C:\Windows\System32.

--- a/Pen-Test/Key-Logger.ps1
+++ b/Pen-Test/Key-Logger.ps1
@@ -1,3 +1,4 @@
+# For authorized testing only. See README.md for ethical use guidelines.
 <#
 .SYNOPSIS
     A simple keylogger script that logs key presses to a specified file.

--- a/Pen-Test/Site-Stress-Test-While.ps1
+++ b/Pen-Test/Site-Stress-Test-While.ps1
@@ -1,3 +1,4 @@
+# For authorized testing only. See README.md for ethical use guidelines.
 <#
 .SYNOPSIS
     This script performs a stress test on a specified web site by sending multiple concurrent requests in a loop.

--- a/Pen-Test/Site-Stress-Test.ps1
+++ b/Pen-Test/Site-Stress-Test.ps1
@@ -1,3 +1,4 @@
+# For authorized testing only. See README.md for ethical use guidelines.
 $targetURL = "tsg.com"
 $requestCount = 10000
 $MaxThreads = 505

--- a/Pen-Test/brute.ps1
+++ b/Pen-Test/brute.ps1
@@ -1,3 +1,4 @@
+# For authorized testing only. See README.md for ethical use guidelines.
 # Target Information
 $TargetURL = ""
 $LoginEndpoint = "/login"

--- a/Pen-Test/network-probe.ps1
+++ b/Pen-Test/network-probe.ps1
@@ -1,3 +1,4 @@
+# For authorized testing only. See README.md for ethical use guidelines.
 <#
 .SYNOPSIS
     Gathers and displays basic network information.

--- a/Pen-Test/payload.ps1
+++ b/Pen-Test/payload.ps1
@@ -1,3 +1,4 @@
+# For authorized testing only. See README.md for ethical use guidelines.
 $baseUrl = ""
 $payloads = @(
     "<script>alert(1)</script>"

--- a/Pen-Test/ping-scanner.ps1
+++ b/Pen-Test/ping-scanner.ps1
@@ -1,3 +1,4 @@
+# For authorized testing only. See README.md for ethical use guidelines.
 param (
     [string]$ipAddress = "127.0.0.1",
     [int[]]$ports = @(80, 443, 8080)
@@ -9,5 +10,4 @@ foreach ($port in $ports) {
         Write-Output "Port $port is open on $ipAddress"
     } else {
         Write-Output "Port $port is closed on $ipAddress"
-    }
-}
+    }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# The Script Lab
+
+This repository provides a collection of PowerShell and related scripts for security research and system management. Some scripts are designed for penetration-testing scenarios.
+
+## Ethical Use Notice
+
+Use these scripts **only** on systems that you own or where you have been granted explicit, written permission to perform testing. Unauthorized or malicious use of these scripts may violate the law and ethical guidelines. The maintainers assume no responsibility for misuse.
+


### PR DESCRIPTION
## Summary
- add README with a notice about responsible penetration-testing
- insert README notice comments at top of penetration-testing scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d93a569a88324907c3965ce174ec0