### PR TITLE
Add Pester test and enable CI test run

### DIFF
--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -42,6 +42,11 @@ jobs:
           includeRule: '"PSAvoidGlobalAliases", "PSAvoidUsingConvertToSecureStringWithPlainText"'
           output: results.sarif
 
+      - name: Run Pester tests
+        shell: pwsh
+        run: |
+          Invoke-Pester -Path ./tests
+
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
         uses: github/codeql-action/upload-sarif@v3

--- a/tests/api-auth-script.Tests.ps1
+++ b/tests/api-auth-script.Tests.ps1
@@ -1,0 +1,9 @@
+Describe "api-auth-script" {
+    It "creates the expected Authorization header" {
+        Mock Invoke-RestMethod {}
+        . "$PSScriptRoot/../API/api-auth-script.ps1"
+        $expected = 'Basic MTIzIDk3IDEwMCAxMDkgMTA1IDExMCAxMjUgNTggMTIzIDExMiA5NyAxMTUgMTE1IDExOSAxMTEgMTE0IDEwMCAxMjU='
+        $basicAuthHeader | Should -Be $expected
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `api-auth-script.Tests.ps1` Pester test
- run `Invoke-Pester` in CI workflow

## Testing
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester -Path ./tests'` *(fails: module Pester could not be loaded)*

------
https://chatgpt.com/codex/tasks/task_e_686d9192cb6883249ac004f838675ba9